### PR TITLE
Allow Monolog 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
     "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
     "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
-    "monolog/monolog": "^1.13 || ^2.0"
+    "monolog/monolog": "^1.13 || ^2.0 || ^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Allow dowstreams to avoid conflicts with Monolog 3.0 dependencies.