### PR TITLE
Update Symfony components and Monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
   "homepage": "https://github.com/bamboohr/monolog-cascade",
   "require": {
     "php": ">=8.1",
-    "symfony/config": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
-    "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
-    "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
-    "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.3",
-    "monolog/monolog": "^1.13 || ^2.0 || ^3.0"
+    "symfony/config": "^7.1",
+    "symfony/options-resolver": "^7.1",
+    "symfony/serializer": "^7.1",
+    "symfony/yaml": "^7.1",
+    "monolog/monolog": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Symfony packages 7.1 only support PHP >= 8.1
Monolog >= 3.0